### PR TITLE
More validation: require `data_type` in `cvar_define`

### DIFF
--- a/phir/model.py
+++ b/phir/model.py
@@ -41,9 +41,23 @@ class CVarDefine(Data):
     """Defining Classical Variables."""
 
     data: Literal["cvar_define"]
-    data_type: str = "i64"
+    data_type: Literal["i64", "i32", "u64", "u32"]
     variable: Sym
     size: PositiveInt | None
+
+    @model_validator(mode="after")
+    def check_size(self: CVarDefine) -> CVarDefine:
+        """Checks whether size fits the data_type."""
+        msg = "`size` is greater than what `data_type` can handle"
+        if self.size:
+            match self.data_type:
+                case "i64" | "u64":
+                    if self.size > 64:  # noqa: PLR2004
+                        raise ValueError(msg)
+                case "i32" | "u32":
+                    if self.size > 32:  # noqa: PLR2004
+                        raise ValueError(msg)
+        return self
 
 
 class QVarDefine(Data):

--- a/schema.json
+++ b/schema.json
@@ -133,7 +133,12 @@
           "title": "Data"
         },
         "data_type": {
-          "default": "i64",
+          "enum": [
+            "i64",
+            "i32",
+            "u64",
+            "u32"
+          ],
           "title": "Data Type",
           "type": "string"
         },
@@ -156,6 +161,7 @@
       },
       "required": [
         "data",
+        "data_type",
         "variable",
         "size"
       ],

--- a/spec.md
+++ b/spec.md
@@ -87,12 +87,13 @@ To define or create a variable, the following structure is employed:
 ```json5
 {
   "data": "cvar_define",
-  "data_type": str,  // Currently, should be "i64"
+  "data_type": str,  // Preferably "i64"
   "variable": str,  // The variable symbol
   "size": int  // Optional
 }
 ```
 
+- `"data_type"`: One of "i64", "i32", "u64", "u32".
 - `"variable"`: Represents the symbol tied to the classical variable. By default, all variables are initialized with a
 value of 0.
 - `"size"`: Even though every variable is internally represented as an i64, a size can be specified. This correlates
@@ -143,7 +144,7 @@ instance, the 1st qubit of the quantum variable `"q"` is represented as `["q", 1
 ## Classical operations
 
 Classical operations are all those operations that manipulate classical information. In the current PECOS
-implementation, all classical variables are implemented as 32-bit signed integers (i64).
+implementation, all classical variables are implemented as 64-bit signed integers (i64).
 
 ### Assigning values to Classical Variables
 


### PR DESCRIPTION
Fixes #13 and restricts classical variables' data type to be one of `"i64"`, `"i32"`, `"u64"`, and `"u32"`.

EDIT: I merged non-spec changes in #15 