### PR TITLE
feat(spec): introduce Skip mop

### DIFF
--- a/phir/model.py
+++ b/phir/model.py
@@ -213,6 +213,11 @@ class TQOp(Op):
         return self
 
 
+QOp: TypeAlias = MeasOp | SQOp | TQOp
+
+# Classical Operations
+
+
 class COp(Op):
     """Classical operation."""
 
@@ -250,18 +255,44 @@ class FFCall(Op):
     args: list[int | Sym | COp | Bit]
 
 
+# Machine Operations
+
 Duration = NewType("Duration", tuple[float, Literal["s", "ms", "us", "ns"]])
 
 
-class MOp(Op):
+class MOp(Op, abc.ABC):
     """Machine operation."""
 
+    model_config = ConfigDict(extra="forbid")
+
     mop: str
+    args: list[Bit] | None = None
     duration: Duration | None = None
 
 
-QOp: TypeAlias = MeasOp | SQOp | TQOp
-OpType: TypeAlias = FFCall | COp | QOp | MOp | Barrier
+class IdleMOp(MOp):
+    """Idle machine op."""
+
+    mop: Literal["Idle"]
+    args: list[Bit]
+    duration: Duration
+
+
+class TransportMOp(MOp):
+    """Transport machine op."""
+
+    mop: Literal["Transport"]
+    duration: Duration
+
+
+class SkipMOp(MOp):
+    """Skip machine op."""
+
+    mop: Literal["Skip"]
+
+
+MOpType: TypeAlias = IdleMOp | TransportMOp | SkipMOp
+OpType: TypeAlias = FFCall | COp | QOp | MOpType | Barrier
 
 
 # Blocks

--- a/schema.json
+++ b/schema.json
@@ -365,6 +365,73 @@
       "title": "FFCall",
       "type": "object"
     },
+    "IdleMOp": {
+      "additionalProperties": false,
+      "description": "Idle machine op.",
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Metadata"
+        },
+        "mop": {
+          "const": "Idle",
+          "title": "Mop"
+        },
+        "args": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "minimum": 0,
+                "type": "integer"
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Args",
+          "type": "array"
+        },
+        "duration": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "s",
+                "ms",
+                "us",
+                "ns"
+              ],
+              "type": "string"
+            }
+          ],
+          "title": "Duration",
+          "type": "array"
+        }
+      },
+      "required": [
+        "mop",
+        "args",
+        "duration"
+      ],
+      "title": "IdleMOp",
+      "type": "object"
+    },
     "IfBlock": {
       "additionalProperties": false,
       "description": "If/else block.",
@@ -407,7 +474,13 @@
                 "$ref": "#/$defs/TQOp"
               },
               {
-                "$ref": "#/$defs/MOp"
+                "$ref": "#/$defs/IdleMOp"
+              },
+              {
+                "$ref": "#/$defs/TransportMOp"
+              },
+              {
+                "$ref": "#/$defs/SkipMOp"
               },
               {
                 "$ref": "#/$defs/Barrier"
@@ -447,7 +520,13 @@
                     "$ref": "#/$defs/TQOp"
                   },
                   {
-                    "$ref": "#/$defs/MOp"
+                    "$ref": "#/$defs/IdleMOp"
+                  },
+                  {
+                    "$ref": "#/$defs/TransportMOp"
+                  },
+                  {
+                    "$ref": "#/$defs/SkipMOp"
                   },
                   {
                     "$ref": "#/$defs/Barrier"
@@ -479,61 +558,6 @@
         "true_branch"
       ],
       "title": "IfBlock",
-      "type": "object"
-    },
-    "MOp": {
-      "additionalProperties": false,
-      "description": "Machine operation.",
-      "properties": {
-        "metadata": {
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Metadata"
-        },
-        "mop": {
-          "title": "Mop",
-          "type": "string"
-        },
-        "duration": {
-          "anyOf": [
-            {
-              "maxItems": 2,
-              "minItems": 2,
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "enum": [
-                    "s",
-                    "ms",
-                    "us",
-                    "ns"
-                  ],
-                  "type": "string"
-                }
-              ],
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Duration"
-        }
-      },
-      "required": [
-        "mop"
-      ],
-      "title": "MOp",
       "type": "object"
     },
     "MeasOp": {
@@ -832,7 +856,13 @@
                 "$ref": "#/$defs/TQOp"
               },
               {
-                "$ref": "#/$defs/MOp"
+                "$ref": "#/$defs/IdleMOp"
+              },
+              {
+                "$ref": "#/$defs/TransportMOp"
+              },
+              {
+                "$ref": "#/$defs/SkipMOp"
               },
               {
                 "$ref": "#/$defs/Barrier"
@@ -857,6 +887,87 @@
         "ops"
       ],
       "title": "SeqBlock",
+      "type": "object"
+    },
+    "SkipMOp": {
+      "additionalProperties": false,
+      "description": "Skip machine op.",
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Metadata"
+        },
+        "mop": {
+          "const": "Skip",
+          "title": "Mop"
+        },
+        "args": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Args"
+        },
+        "duration": {
+          "anyOf": [
+            {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "s",
+                    "ms",
+                    "us",
+                    "ns"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration"
+        }
+      },
+      "required": [
+        "mop"
+      ],
+      "title": "SkipMOp",
       "type": "object"
     },
     "TQOp": {
@@ -970,6 +1081,80 @@
       ],
       "title": "TQOp",
       "type": "object"
+    },
+    "TransportMOp": {
+      "additionalProperties": false,
+      "description": "Transport machine op.",
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Metadata"
+        },
+        "mop": {
+          "const": "Transport",
+          "title": "Mop"
+        },
+        "args": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Args"
+        },
+        "duration": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "s",
+                "ms",
+                "us",
+                "ns"
+              ],
+              "type": "string"
+            }
+          ],
+          "title": "Duration",
+          "type": "array"
+        }
+      },
+      "required": [
+        "mop",
+        "duration"
+      ],
+      "title": "TransportMOp",
+      "type": "object"
     }
   },
   "additionalProperties": false,
@@ -1025,7 +1210,13 @@
             "$ref": "#/$defs/TQOp"
           },
           {
-            "$ref": "#/$defs/MOp"
+            "$ref": "#/$defs/IdleMOp"
+          },
+          {
+            "$ref": "#/$defs/TransportMOp"
+          },
+          {
+            "$ref": "#/$defs/SkipMOp"
           },
           {
             "$ref": "#/$defs/Barrier"

--- a/spec.md
+++ b/spec.md
@@ -480,6 +480,15 @@ idling and transport include:
 }
 ```
 
+The "Skip" `"mop"` is the empty operation that indicates *do nothing*. It is used in place of operations that will
+have no effect on the machine state, such as the global phase operation.
+
+```json5
+{
+  "mop": "Skip",
+}
+```
+
 ## Blocks
 
 In the present version of PHIR/PECOS, blocks serve a dual purpose: they group operations and other blocks, and they


### PR DESCRIPTION
See https://github.com/CQCL/pytket-phir/pull/138

We currently do not have validation for `mop`s [in the model](https://github.com/CQCL/phir/blob/main/phir/model.py#L256-L260). If desired, I can add it.